### PR TITLE
Add validation CI workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,14 @@
+name: CI
+on: [push]
+
+jobs:
+  validate:
+    timeout-minutes: 5
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v3
+
+      - name: Validate s3fs binary checksum
+        run: cat SHASUM_256 | shasum -a 256 -c

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,6 +1,10 @@
 name: CI
 on: [push]
 
+concurrency:
+  group: ${{ github.ref }}
+  cancel-in-progress: true
+
 jobs:
   validate:
     timeout-minutes: 5

--- a/SHASUM_256
+++ b/SHASUM_256
@@ -1,1 +1,1 @@
-e5b650bcd7de878de5a563eaa0bc8bd38ee71af37225a4ea85e017a0c8f85310 s3fs_1.91+git-v1.91-3_arm64.deb
+e5b650bcd7de878de5a563eaa0bc8bd38ee71af37225a4ea85e017a0c8f85310  s3fs_1.91+git-v1.91-3_arm64.deb


### PR DESCRIPTION
Adding a validation CI workflow for the `s3fs` binary's `sha256` checksum.

While doing it, I noticed that the checksum `SHASUM_256` was actually poorly formatted 😅 - It was missing a space separating the actual hash from the file's name. It was:

```
e5b650bcd7de878de5a563eaa0bc8bd38ee71af37225a4ea85e017a0c8f85310 s3fs_1.91+git-v1.91-3_arm64.deb
```

And I updated it to:

```
e5b650bcd7de878de5a563eaa0bc8bd38ee71af37225a4ea85e017a0c8f85310  s3fs_1.91+git-v1.91-3_arm64.deb
```

**Notice the double space separating the two words!** (which is the correct format for the checksums).

## Testing

Validated the workflow was failing locally using `act`:

<details>
<summary>Failing workflow</summary>

```
❯ act -j validate
WARN  ⚠ You are using Apple M1 chip and you have not specified container architecture, you might encounter issues while running act. If so, try running it with '--container-architecture linux/amd64'. ⚠
[CI/validate] 🚀  Start image=catthehacker/ubuntu:act-latest
[CI/validate]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[CI/validate]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[CI/validate]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[CI/validate] ⭐ Run Main Checkout repository
[CI/validate]   🐳  docker cp src=/Users/ralves/Repos/s3fs-arm/. dst=/Users/ralves/Repos/s3fs-arm
[CI/validate]   ✅  Success - Main Checkout repository
[CI/validate] ⭐ Run Main Validate s3fs binary checksum
[CI/validate]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/1] user= workdir=
| shasum: standard input: no properly formatted SHA checksum lines found
[CI/validate]   ❌  Failure - Main Validate s3fs binary checksum
[CI/validate] exitcode '1': failure
[CI/validate] 🏁  Job failed
Error: Job 'validate' failed
```

</details>

Then, fixed the checksum on the shasum file (as explained in the beginning of the PR description) and validated it passed:

<details>
<summary>Successful passing workflow</summary>

```
❯ act -j validate
WARN  ⚠ You are using Apple M1 chip and you have not specified container architecture, you might encounter issues while running act. If so, try running it with '--container-architecture linux/amd64'. ⚠
[CI/validate] 🚀  Start image=catthehacker/ubuntu:act-latest
[CI/validate]   🐳  docker pull image=catthehacker/ubuntu:act-latest platform= username= forcePull=true
[CI/validate]   🐳  docker create image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[CI/validate]   🐳  docker run image=catthehacker/ubuntu:act-latest platform= entrypoint=["tail" "-f" "/dev/null"] cmd=[]
[CI/validate] ⭐ Run Main Checkout repository
[CI/validate]   🐳  docker cp src=/Users/ralves/Repos/s3fs-arm/. dst=/Users/ralves/Repos/s3fs-arm
[CI/validate]   ✅  Success - Main Checkout repository
[CI/validate] ⭐ Run Main Validate s3fs binary checksum
[CI/validate]   🐳  docker exec cmd=[bash --noprofile --norc -e -o pipefail /var/run/act/workflow/1] user= workdir=
| s3fs_1.91+git-v1.91-3_arm64.deb: OK
[CI/validate]   ✅  Success - Main Validate s3fs binary checksum
[CI/validate] 🏁  Job succeeded
```

</details>